### PR TITLE
remove client_id

### DIFF
--- a/lib/domainr.rb
+++ b/lib/domainr.rb
@@ -13,7 +13,7 @@ module Domainr
   end
 
   def self.client_id
-    @client_id || 'domainr_rubygem'
+    @client_id || '{your-mashape-key}'
   end
 
   def search(term)


### PR DESCRIPTION
Due to API abuse, we're locking these down further. Details in our [API documentation](http://domainr.build/docs/authentication).
